### PR TITLE
Update lib dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Example of custom Java runtime using jlink in a multi-stage container build
-FROM eclipse-temurin:17 as jre-build
+FROM eclipse-temurin:17
 
 ARG PROJECT_VERSION
 ARG DATA_DOG_API_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable-20211220
+# Example of custom Java runtime using jlink in a multi-stage container build
+FROM eclipse-temurin:17 as jre-build
 
 ARG PROJECT_VERSION
 ARG DATA_DOG_API_KEY
@@ -7,18 +8,18 @@ ADD build/libs/bob-jr-lava-${PROJECT_VERSION}-all.jar /opt/bob-jr/bob-jr-lava-al
 # install openJDK 14
 RUN apt-get update
 RUN apt-get install -y wget apt-transport-https gnupg curl
-RUN wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public
-RUN gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public
-RUN gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg
-RUN rm adoptopenjdk-keyring.gpg
-RUN mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings
-RUN echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
-RUN apt-get update
-RUN apt-get install -y adoptopenjdk-14-hotspot
+#RUN wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public
+#RUN gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public
+#RUN gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg
+#RUN rm adoptopenjdk-keyring.gpg
+#RUN mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings
+#RUN echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
+#RUN apt-get update
+#RUN apt-get install -y adoptopenjdk-14-hotspot
 
 ENV DD_AGENT_MAJOR_VERSION=7
 ENV DD_API_KEY=${DATA_DOG_API_KEY}
 ENV DD_SITE="datadoghq.com"
 RUN curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 
-ENTRYPOINT java -jar /opt/bob-jr/bob-jr-lava-all.jar
+CMD ["java", "-jar", "/opt/bob-jr/bob-jr-lava-all.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'application'
 }
 
-project.setVersion("0.0.4")
+project.setVersion("0.0.5")
 
 repositories {   // repositories for Jar's you access in your code
     jcenter()
@@ -40,7 +40,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     implementation group: 'org.slf4j', name: 'log4j-over-slf4j', version: '1.7.32'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.6'
-    implementation group: 'com.discord4j', name: 'discord4j-core', version: '3.2.2'
+    implementation group: 'com.discord4j', name: 'discord4j-core', version: '3.2.4'
     implementation group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.76'
     implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '1.4.1'
     implementation 'com.google.cloud:google-cloud-logging-logback:0.123.4-alpha'


### PR DESCRIPTION
Updating the Discord4J version helped to uncover an issue with the bot permissions. In the earlier version, the app would throw an error silently. After updating, it produced an error saying that it didn't have the proper intent. 

The Docker update was just something done on the side that should speed up build times. 