### PR TITLE
Updating to a maintained version of Lavaplayer 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,11 @@ plugins {
 project.setVersion("0.1.1")
 
 repositories {   // repositories for Jar's you access in your code
-    jcenter()
     mavenCentral()
+    maven {
+        name 'Lavalink Repository'
+        url 'https://maven.lavalink.dev/snapshots'
+    }
     maven {
         url 'https://m2.dv8tion.net/releases'
     }
@@ -43,7 +46,7 @@ dependencies {
     implementation group: 'org.slf4j', name: 'log4j-over-slf4j', version: '1.7.32'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.6'
     implementation group: 'com.discord4j', name: 'discord4j-core', version: '3.2.4'
-    implementation group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.78'
+    implementation group: 'dev.arbjerg', name: 'lavaplayer', version: '0eaeee195f0315b2617587aa3537fa202df07ddc-SNAPSHOT'
     implementation group: 'com.github.aikaterna', name: 'lavaplayer-natives', version: 'original-SNAPSHOT'
     implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '1.4.1'
     implementation 'com.google.cloud:google-cloud-logging-logback:0.123.4-alpha'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'application'
 }
 
-project.setVersion("0.1.1")
+project.setVersion("0.2.0")
 
 repositories {   // repositories for Jar's you access in your code
     mavenCentral()


### PR DESCRIPTION
The original Lavaplayer hasn't been updated in about 3 years. There is a fork that is being maintained here: https://github.com/lavalink-devs/lavaplayer/

Using a snapshot version because there was a recent change in YT that needed to be fixed: https://github.com/lavalink-devs/lavaplayer/issues/90